### PR TITLE
GithubPagesのデプロイをmainブランチにマージされたらではなくworkflow_dispatchにして手動でデプロイできる用に対応

### DIFF
--- a/.github/workflows/pull_request_github_page.yaml
+++ b/.github/workflows/pull_request_github_page.yaml
@@ -1,7 +1,13 @@
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'environment'
+        required: true
+        type: choice
+        options:
+            - staging
+            - deploy
 permissions:
   actions: write
   checks: write
@@ -20,4 +26,6 @@ jobs:
       - run: pip install plantuml_markdown
       - run: pip install mkdocs-git-revision-date-plugin
       - run: mkdocs build
-      - run: mkdocs gh-deploy --force
+      - name: deploy
+        if: "${{ github.event.inputs.environment == 'deploy' }}"
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
GithubActionsなどメモ以外の更新がされた時にページ更新されたら困ることがあるので

